### PR TITLE
Fix/env are strings

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,7 +74,9 @@ function RedisCache(options) {
     function() {
       return DEFAULT_RETRY_MS;
     };
-  if (options.maxAge && isNaN(options.maxAge)) {
+  const isNumberRegEx = /^\d+$/;
+
+  if (options.maxAge && options.maxAge !== "number" && !isNumberRegEx.test(options.maxAge)) {
     throw new Error(`Unparsable maxAge option: '${options.maxAge}'`);
   }
   this.poolResolveTimeMs = options.poolTime;

--- a/index.js
+++ b/index.js
@@ -74,6 +74,10 @@ function RedisCache(options) {
     function() {
       return DEFAULT_RETRY_MS;
     };
+  this.maxAge = Number(options.maxAge)
+  if (options.maxAge && !this.maxAge) {
+    self.emit("error", `Unparsable maxAge option: '${options.maxAge}'`);
+  }
   this.poolResolveTimeMs = options.poolTime;
   this.resolveGetPoolTimer = false;
   this.getPool = [];

--- a/index.js
+++ b/index.js
@@ -162,7 +162,7 @@ function RedisCache(options) {
         serialize(value)
       );
     } else if (options && options.maxAge !== undefined) {
-      return this.set(key, value, options.maxAge);
+      return this.set(key, value, Number(options.maxAge));
     } else {
       return this.client.setAsync(key, serialize(value));
     }

--- a/test/index.js
+++ b/test/index.js
@@ -325,7 +325,6 @@ describe("RedisCache", function () {
   it("should return an error if maxAge values cannot be parsed as numbers", function (done) {
     try {
     var target = new RedisCache({ maxAge: "unknown"});
-
     } catch(err) {
       err.context.should.equal("Unparsable maxAge option: 'unknown'")
       done()

--- a/test/index.js
+++ b/test/index.js
@@ -306,27 +306,35 @@ describe("RedisCache", function () {
     });
   });
 
-  it("should set the value in redis with default ttl if without ttl", function (done) {
+  it("should set the value in redis permanently if maxAge is empty string", function (done) {
+    var target = new RedisCache({ maxAge: ""});
+    target.set("key", "value")
+
+    assert(target.client.cache.key.ttl === null);
+    done()
+  });
+
+  it("should set the value in redis with a ttl if given in options", function (done) {
     var target = new RedisCache({ maxAge: 1000 });
-    target.set("key", "value").then(function () {
-      target.client.cache.key.ttl.should.equal(1);
+    target.set("key", "value", 2000).then(function () {
+      target.client.cache.key.ttl.should.equal(2);
       done();
     });
   });
 
-  it("should set the value in redis with default ttl to the parsed number from config", function (done) {
-    var target = new RedisCache({ maxAge: "1000"});
-    target.set("key", "value").then(function () {
-      target.client.cache.key.ttl.should.equal(1);
-      done();
+    it("should set the value in redis with a ttl if given as a parsable number in a string", function (done) {
+      var target = new RedisCache({ maxAge: "1000"});
+      target.set("key", "value").then(function () {
+        target.client.cache.key.ttl.should.equal(1);
+        done();
+      });
     });
-  });
 
-  it("should return an error if maxAge values cannot be parsed as numbers", function (done) {
+  it("should throw on initialization if maxAge is a unparsable strings", function (done) {
     try {
-    var target = new RedisCache({ maxAge: "unknown"});
-    } catch(err) {
-      err.context.should.equal("Unparsable maxAge option: 'unknown'")
+      new RedisCache({ maxAge: "unknown"});
+    } catch(error) {
+      error.message.should.equal("Unparsable maxAge option: 'unknown'")
       done()
     }
   });

--- a/test/index.js
+++ b/test/index.js
@@ -314,6 +314,14 @@ describe("RedisCache", function () {
     });
   });
 
+  it("should set the value in redis with default ttl to the parsed number from config", function (done) {
+    var target = new RedisCache({ maxAge: "1000"});
+    target.set("key", "value").then(function () {
+      target.client.cache.key.ttl.should.equal(1);
+      done();
+    });
+  });
+
   it("should set the value in redis as json", function (done) {
     var target = new RedisCache();
     target.set("key", { field: "value" }, 1500).then(function () {

--- a/test/index.js
+++ b/test/index.js
@@ -2,39 +2,37 @@
 require("chai").should();
 
 var redisStub = {
-  createClient: function (options) {
+  createClient: function(options) {
     var cache = (options || {}).cache || {};
     var onCallbacks = {};
     return {
       cache: cache,
       options: options,
-      get: function (key, callback) {
+      get: function(key, callback) {
         if (key === "error") {
           return callback(new Error("redis error"));
         }
         if (cache.hasOwnProperty(key)) {
           callback(null, cache[key].value);
-        }
-        else {
+        } else {
           callback(null, null);
         }
       },
-      mget: function (keys, callback) {
+      mget: function(keys, callback) {
         if (keys === "error") {
           return callback(new Error("redis error"));
         }
         const results = [];
-        keys.forEach(function(key){
+        keys.forEach(function(key) {
           if (cache.hasOwnProperty(key)) {
             results.push(cache[key].value);
-          }
-          else {
+          } else {
             results.push(null);
           }
         });
         callback(null, results);
       },
-      setex: function (key, ttl, value, callback) {
+      setex: function(key, ttl, value, callback) {
         if (key === "error") {
           return callback(new Error("redis error"));
         }
@@ -44,7 +42,7 @@ var redisStub = {
         };
         callback(null, null);
       },
-      set: function (key, value, callback) {
+      set: function(key, value, callback) {
         if (key === "error") {
           return callback(new Error("redis error"));
         }
@@ -54,21 +52,21 @@ var redisStub = {
         };
         callback(null, null);
       },
-      del: function (key, callback) {
+      del: function(key, callback) {
         delete cache[key];
         callback();
       },
-      keys: function (filter, callback) {
+      keys: function(filter, callback) {
         callback(null, Object.keys(cache));
       },
-      on: function (event, callback) {
+      on: function(event, callback) {
         if (!onCallbacks[event]) {
           onCallbacks[event] = [callback];
         } else {
           onCallbacks[event].push(callback);
         }
       },
-      emit: function (event, err) {
+      emit: function(event, err) {
         if (onCallbacks[event]) {
           for (var i = 0; i < onCallbacks[event].length; i++) {
             onCallbacks[event][i](err);
@@ -79,11 +77,11 @@ var redisStub = {
   }
 };
 var proxyquire = require("proxyquire"),
-    RedisCache = proxyquire("../", { redis: redisStub }),
-    assert = require("assert");
+  RedisCache = proxyquire("../", { redis: redisStub }),
+  assert = require("assert");
 
-describe("RedisCache", function () {
-  it("should pass options to redis client", function () {
+describe("RedisCache", function() {
+  it("should pass options to redis client", function() {
     var options = {
       host: "127.0.0.1",
       port: 6379,
@@ -93,7 +91,7 @@ describe("RedisCache", function () {
     target.client.options.should.eql(options);
   });
 
-  it("should add retry_stategy option if none specified", function () {
+  it("should add retry_stategy option if none specified", function() {
     var options = {
       host: "127.0.0.1",
       port: 6379
@@ -103,22 +101,22 @@ describe("RedisCache", function () {
     target.client.options.retry_strategy().should.eql(2000);
   });
 
-  it("should get the value from redis as json", function (done) {
+  it("should get the value from redis as json", function(done) {
     var options = {
       cache: {
         key: {
-          value: "\"value\""
+          value: '"value"'
         }
       }
     };
     var target = new RedisCache(options);
-    target.get("key").then(function (value) {
+    target.get("key").then(function(value) {
       value.should.equal("value");
       done();
     });
   });
 
-  it("should return null if value in redis is \"null\"", function (done) {
+  it('should return null if value in redis is "null"', function(done) {
     var options = {
       cache: {
         key: {
@@ -127,14 +125,14 @@ describe("RedisCache", function () {
       }
     };
     var target = new RedisCache(options);
-    target.get("key").then(function (value) {
+    target.get("key").then(function(value) {
       assert(value === null);
       done();
     });
   });
 
   // undefined means "not found" in contract with exp-asynccache so we cannot return it.
-  it("should return \"undefined\" if value in redis is \"undefined\"", function (done) {
+  it('should return "undefined" if value in redis is "undefined"', function(done) {
     var options = {
       cache: {
         key: {
@@ -143,15 +141,15 @@ describe("RedisCache", function () {
       }
     };
     var target = new RedisCache(options);
-    target.get("key").then(function (value) {
+    target.get("key").then(function(value) {
       assert(value === "undefined");
       done();
     });
   });
 
-  it("should emit client errors", function (done) {
+  it("should emit client errors", function(done) {
     var target = new RedisCache();
-    target.on("error", function (err) {
+    target.on("error", function(err) {
       assert(err);
       err.message.should.equal("error");
       done();
@@ -159,39 +157,39 @@ describe("RedisCache", function () {
     target.client.emit("error", new Error("error"));
   });
 
-  it("should delete the key from redis", function (done) {
+  it("should delete the key from redis", function(done) {
     var options = {
       cache: {
         key: {
-          value: "\"value\""
+          value: '"value"'
         }
       }
     };
     var target = new RedisCache(options);
-    target.del("key").then(function () {
-      target.has("key").then(function (value) {
+    target.del("key").then(function() {
+      target.has("key").then(function(value) {
         value.should.equal(false);
         done();
       });
     });
   });
 
-  it("should delete all keys from redis when resetting", function (done) {
+  it("should delete all keys from redis when resetting", function(done) {
     var options = {
       cache: {
         key: {
-          value: "\"value\""
+          value: '"value"'
         },
         key2: {
-          value: "\"value\""
+          value: '"value"'
         }
       }
     };
     var target = new RedisCache(options);
-    target.reset().then(function () {
-      target.has("key").then(function (value) {
+    target.reset().then(function() {
+      target.has("key").then(function(value) {
         value.should.equal(false);
-        target.has("key2").then(function (value) {
+        target.has("key2").then(function(value) {
           value.should.equal(false);
           done();
         });
@@ -199,37 +197,37 @@ describe("RedisCache", function () {
     });
   });
 
-  it("should peek the value from redis as json", function (done) {
+  it("should peek the value from redis as json", function(done) {
     var options = {
       cache: {
         key: {
-          value: "\"value\""
+          value: '"value"'
         }
       }
     };
     var target = new RedisCache(options);
-    target.peek("key").then(function (value) {
+    target.peek("key").then(function(value) {
       value.should.equal("value");
       done();
     });
   });
 
-  it("should have the key if it is set", function (done) {
+  it("should have the key if it is set", function(done) {
     var options = {
       cache: {
         key: {
-          value: "\"value\""
+          value: '"value"'
         }
       }
     };
     var target = new RedisCache(options);
-    target.has("key").then(function (value) {
+    target.has("key").then(function(value) {
       value.should.equal(true);
       done();
     });
   });
 
-  it("should have the key if it is set to \"null\"", function (done) {
+  it('should have the key if it is set to "null"', function(done) {
     var options = {
       cache: {
         key: {
@@ -238,13 +236,13 @@ describe("RedisCache", function () {
       }
     };
     var target = new RedisCache(options);
-    target.has("key").then(function (value) {
+    target.has("key").then(function(value) {
       value.should.equal(true);
       done();
     });
   });
 
-  it("should have the key if it is set to \"undefined\"", function (done) {
+  it('should have the key if it is set to "undefined"', function(done) {
     var options = {
       cache: {
         key: {
@@ -253,111 +251,121 @@ describe("RedisCache", function () {
       }
     };
     var target = new RedisCache(options);
-    target.has("key").then(function (value) {
+    target.has("key").then(function(value) {
       value.should.equal(true);
       done();
     });
   });
 
-  it("should not have the key if it is missing", function (done) {
+  it("should not have the key if it is missing", function(done) {
     var target = new RedisCache();
-    target.has("key").then(function (value) {
+    target.has("key").then(function(value) {
       value.should.equal(false);
       done();
     });
   });
 
-  it("should return undefined if key is missing", function (done) {
+  it("should return undefined if key is missing", function(done) {
     var target = new RedisCache();
-    target.get("key").then(function (value) {
+    target.get("key").then(function(value) {
       assert(value === undefined);
       done();
     });
   });
 
-  it("should reject the promise on get error from redis", function (done) {
+  it("should reject the promise on get error from redis", function(done) {
     var target = new RedisCache();
-    target.get("error").then(done, function () {
+    target.get("error").then(done, function() {
       done();
     });
   });
 
-  it("should set the value in redis with ttl in nearest seconds", function (done) {
+  it("should set the value in redis with ttl in nearest seconds", function(done) {
     var target = new RedisCache();
-    target.set("key", "value", 1500).then(function () {
+    target.set("key", "value", 1500).then(function() {
       target.client.cache.key.ttl.should.equal(2);
       done();
     });
   });
 
-  it("should not set the value in redis if ttl is less than 1", function (done) {
+  it("should not set the value in redis if ttl is less than 1", function(done) {
     var target = new RedisCache();
-    target.set("key", "value", 0).then(function () {
+    target.set("key", "value", 0).then(function() {
       assert(target.client.cache.key === undefined);
       done();
     });
   });
 
-  it("should set the value in redis permanently if without ttl", function (done) {
+  it("should set the value in redis permanently if without ttl", function(done) {
     var target = new RedisCache();
-    target.set("key", "value").then(function () {
+    target.set("key", "value").then(function() {
       assert(target.client.cache.key.ttl === null);
       done();
     });
   });
 
-  it("should set the value in redis permanently if maxAge is empty string", function (done) {
-    var target = new RedisCache({ maxAge: ""});
-    target.set("key", "value")
+  it("should set the value in redis permanently if maxAge is empty string", function(done) {
+    var target = new RedisCache({ maxAge: "" });
+    target.set("key", "value");
 
     assert(target.client.cache.key.ttl === null);
-    done()
+    done();
   });
 
-  it("should set the value in redis with a ttl if given in options", function (done) {
+  it("should set the value in redis with a ttl if given in constructor options", function(done) {
     var target = new RedisCache({ maxAge: 1000 });
-    target.set("key", "value").then(function () {
+    target.set("key", "value").then(function() {
       target.client.cache.key.ttl.should.equal(1);
       done();
     });
   });
 
-  it("should set the value in redis with a specifically given ttl that overrides global default values", function (done) {
+  it("should set the value in redis with a specifically given ttl that overrides global default values", function(done) {
     var target = new RedisCache({ maxAge: 1000 });
-    target.set("key", "value", 2000).then(function () {
+    target.set("key", "value", 2000).then(function() {
       target.client.cache.key.ttl.should.equal(2);
       done();
     });
   });
 
-  it("should set the value in redis with a ttl if given as a parsable number in a string", function (done) {
-    var target = new RedisCache({ maxAge: "1000"});
-    target.set("key", "value").then(function () {
+  it("should set the value in redis with a ttl if given as a parsable number in a string", function(done) {
+    var target = new RedisCache({ maxAge: "1000" });
+    target.set("key", "value").then(function() {
       target.client.cache.key.ttl.should.equal(1);
       done();
     });
   });
 
-  it("should throw on initialization if maxAge is a unparsable strings", function (done) {
-    try {
-      new RedisCache({ maxAge: "unknown"});
-    } catch(error) {
-      error.message.should.equal("Unparsable maxAge option: 'unknown'")
-      done()
-    }
-  });
-
-  it("should set the value in redis as json", function (done) {
-    var target = new RedisCache();
-    target.set("key", { field: "value" }, 1500).then(function () {
-      target.client.cache.key.value.should.equal("{\"field\":\"value\"}");
+  it("should set the value in redis without a ttl if default options was given as an empty string", done => {
+    var target = new RedisCache({ maxAge: "" });
+    target.set("key", "value").then(function() {
+      assert(target.client.cache.key.ttl === null);
       done();
     });
   });
 
-  it("should reject the promise on set error from redis", function (done) {
+  ["unknown", "Infinity", "-Infinity", " ", {}, [], Infinity, Math.random].map(input => {
+    it(`should throw on initialization if maxAge is '${input}'`, function(done) {
+      try {
+        new RedisCache({ maxAge: input });
+      } catch (error) {
+        error.message.should.equal(`Unparsable maxAge option: '${input}'`);
+        done();
+      }
+    });
+  });
+
+  it("should set the value in redis as json", function(done) {
     var target = new RedisCache();
-    target.set("error", "value", 1500).then(done, function () {
+    target.set("key", { field: "value" }, 1500).then(function() {
+      target.client.cache.key.value.should.equal('{"field":"value"}');
+      done();
+    });
+  });
+
+  it("should reject the promise on set error from redis", function(done) {
+    var target = new RedisCache();
+    target.set("error", "value", 1500).then(done, function() {
       done();
     });
   });

--- a/test/index.js
+++ b/test/index.js
@@ -314,7 +314,7 @@ describe("RedisCache", function () {
     done()
   });
 
-  it("should set the value in redis with a ttl if given in options", function (done) {
+  it("should set the value in redis with a specifically given ttl", function (done) {
     var target = new RedisCache({ maxAge: 1000 });
     target.set("key", "value", 2000).then(function () {
       target.client.cache.key.ttl.should.equal(2);
@@ -322,13 +322,21 @@ describe("RedisCache", function () {
     });
   });
 
-    it("should set the value in redis with a ttl if given as a parsable number in a string", function (done) {
-      var target = new RedisCache({ maxAge: "1000"});
-      target.set("key", "value").then(function () {
-        target.client.cache.key.ttl.should.equal(1);
-        done();
-      });
+  it("should set the value in redis with a ttl if given in options", function (done) {
+    var target = new RedisCache({ maxAge: 1000 });
+    target.set("key", "value").then(function () {
+      target.client.cache.key.ttl.should.equal(1);
+      done();
     });
+  });
+
+  it("should set the value in redis with a ttl if given as a parsable number in a string", function (done) {
+    var target = new RedisCache({ maxAge: "1000"});
+    target.set("key", "value").then(function () {
+      target.client.cache.key.ttl.should.equal(1);
+      done();
+    });
+  });
 
   it("should throw on initialization if maxAge is a unparsable strings", function (done) {
     try {

--- a/test/index.js
+++ b/test/index.js
@@ -314,18 +314,18 @@ describe("RedisCache", function () {
     done()
   });
 
-  it("should set the value in redis with a specifically given ttl", function (done) {
-    var target = new RedisCache({ maxAge: 1000 });
-    target.set("key", "value", 2000).then(function () {
-      target.client.cache.key.ttl.should.equal(2);
-      done();
-    });
-  });
-
   it("should set the value in redis with a ttl if given in options", function (done) {
     var target = new RedisCache({ maxAge: 1000 });
     target.set("key", "value").then(function () {
       target.client.cache.key.ttl.should.equal(1);
+      done();
+    });
+  });
+
+  it("should set the value in redis with a specifically given ttl that overrides global default values", function (done) {
+    var target = new RedisCache({ maxAge: 1000 });
+    target.set("key", "value", 2000).then(function () {
+      target.client.cache.key.ttl.should.equal(2);
       done();
     });
   });

--- a/test/index.js
+++ b/test/index.js
@@ -322,6 +322,16 @@ describe("RedisCache", function () {
     });
   });
 
+  it("should return an error if maxAge values cannot be parsed as numbers", function (done) {
+    try {
+    var target = new RedisCache({ maxAge: "unknown"});
+
+    } catch(err) {
+      err.context.should.equal("Unparsable maxAge option: 'unknown'")
+      done()
+    }
+  });
+
   it("should set the value in redis as json", function (done) {
     var target = new RedisCache();
     target.set("key", { field: "value" }, 1500).then(function () {


### PR DESCRIPTION
Parse number from maxAge from options

If the maxAge from options are passed from an env variable it is very
likely it is a string. We now try to parse it and use the value as a
number.

The error message was unreadable, as it would cause an infinite recursive
loop ending in a maximum call stack size exceeded and ending the
process.